### PR TITLE
Bugfix Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+source 'https://rubygems.org'
+
 gem "rake"
 gem "kramdown"
 gem "coderay" 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,5 @@
 GEM
+  remote: https://rubygems.org/
   specs:
     coderay (1.1.0)
     kramdown (1.4.2)


### PR DESCRIPTION
If the sources are not already on the machine, `bundle install`
will fail with a warning. This change adds 'https://rubygems.org'
as source.
